### PR TITLE
Pad the top of the terminal so the progress bar clears the tab bar

### DIFF
--- a/Tecolot/TerminalSessionView.swift
+++ b/Tecolot/TerminalSessionView.swift
@@ -792,11 +792,12 @@ final class TerminalSessionController: NSObject, LocalProcessTerminalViewDelegat
 }
 
 final class TerminalSessionContainerView: NSView {
-    // Ghostty uses two points of window padding by default. The side and
-    // bottom padding keep terminal content clear of the window border.
+    // Ghostty uses two points of window padding by default, on all four sides.
+    // The top strip also keeps the OSC 9;4 progress bar off the tab bar.
     private static let padding: CGFloat = 2
 
     let terminal: LocalProcessTerminalView
+    private let topPaddingView = NSView()
     private let leftPaddingView = NSView()
     private let rightPaddingView = NSView()
     private let bottomPaddingView = NSView()
@@ -806,7 +807,7 @@ final class TerminalSessionContainerView: NSView {
         super.init(frame: .zero)
 
         terminal.translatesAutoresizingMaskIntoConstraints = false
-        let paddingViews = [leftPaddingView, rightPaddingView, bottomPaddingView]
+        let paddingViews = [topPaddingView, leftPaddingView, rightPaddingView, bottomPaddingView]
         for view in paddingViews {
             view.translatesAutoresizingMaskIntoConstraints = false
             view.wantsLayer = true
@@ -815,17 +816,22 @@ final class TerminalSessionContainerView: NSView {
 
         addSubview(terminal)
         NSLayoutConstraint.activate([
-            terminal.topAnchor.constraint(equalTo: topAnchor),
+            terminal.topAnchor.constraint(equalTo: topPaddingView.bottomAnchor),
             terminal.leadingAnchor.constraint(equalTo: leftPaddingView.trailingAnchor),
             terminal.trailingAnchor.constraint(equalTo: rightPaddingView.leadingAnchor),
             terminal.bottomAnchor.constraint(equalTo: bottomPaddingView.topAnchor),
 
-            leftPaddingView.topAnchor.constraint(equalTo: topAnchor),
+            topPaddingView.topAnchor.constraint(equalTo: topAnchor),
+            topPaddingView.leadingAnchor.constraint(equalTo: leadingAnchor),
+            topPaddingView.trailingAnchor.constraint(equalTo: trailingAnchor),
+            topPaddingView.heightAnchor.constraint(equalToConstant: Self.padding),
+
+            leftPaddingView.topAnchor.constraint(equalTo: topPaddingView.bottomAnchor),
             leftPaddingView.leadingAnchor.constraint(equalTo: leadingAnchor),
             leftPaddingView.bottomAnchor.constraint(equalTo: bottomPaddingView.topAnchor),
             leftPaddingView.widthAnchor.constraint(equalToConstant: Self.padding),
 
-            rightPaddingView.topAnchor.constraint(equalTo: topAnchor),
+            rightPaddingView.topAnchor.constraint(equalTo: topPaddingView.bottomAnchor),
             rightPaddingView.trailingAnchor.constraint(equalTo: trailingAnchor),
             rightPaddingView.bottomAnchor.constraint(equalTo: bottomPaddingView.topAnchor),
             rightPaddingView.widthAnchor.constraint(equalToConstant: Self.padding),
@@ -849,13 +855,14 @@ final class TerminalSessionContainerView: NSView {
             size.width += Self.padding * 2
         }
         if size.height >= 0 {
-            size.height += Self.padding
+            size.height += Self.padding * 2
         }
         return size
     }
 
     func updatePaddingColor() {
         let color = terminal.nativeBackgroundColor.cgColor
+        topPaddingView.layer?.backgroundColor = color
         leftPaddingView.layer?.backgroundColor = color
         rightPaddingView.layer?.backgroundColor = color
         bottomPaddingView.layer?.backgroundColor = color


### PR DESCRIPTION
`TerminalSessionContainerView` pads the left, right and bottom edges by two points but anchors the terminal flush to the top. The OSC 9;4 progress bar draws in the first few points of the terminal view, so it ended up hard against the tab bar and read as part of the window chrome rather than as something belonging to the terminal.

Ghostty pads all four sides, and its progress bar sits in that strip.

This adds a matching top padding view, anchors the terminal below it, and accounts for the extra strip in the padding colour and in `intrinsicContentSize`.

The bar itself is fixed separately in SwiftTerm, in migueldeicaza/SwiftTerm#646. Without that fix the bar is invisible whenever the Metal renderer is on, which is Tecolot's default, so this change is only visible once that one lands and Tecolot picks it up.
