### PR TITLE
feat: window chrome matches current theme

### DIFF
--- a/Tecolot/ContentView.swift
+++ b/Tecolot/ContentView.swift
@@ -25,14 +25,37 @@ struct ContentView: View {
         workspace.controllers.first
     }
 
+    private var windowTheme: TerminalTheme {
+        workspace.focusedController?.effectiveTheme ?? .fallback
+    }
+
+    private var usesThemeWindowChrome: Bool {
+        workspace.focusedController?.profile.useThemeColorsForWindowChrome ?? true
+    }
+
+    private var windowChromeBackground: AnyShapeStyle {
+        usesThemeWindowChrome
+            ? AnyShapeStyle(windowTheme.background.swiftUIColor)
+            : AnyShapeStyle(.bar)
+    }
+
     var body: some View {
         TerminalPaneContainer(
             workspace: workspace,
             document: document,
             revision: workspace.revision
         )
-            .background(WindowTabbingConfigurator())
-            .toolbarBackgroundVisibility(.visible, for: .windowToolbar)
+            .background(WindowTabbingConfigurator(
+                theme: usesThemeWindowChrome ? windowTheme : nil
+            ))
+            .toolbarBackground(windowChromeBackground, for: .windowToolbar)
+            .toolbarBackgroundVisibility(
+                usesThemeWindowChrome ? .visible : .automatic,
+                for: .windowToolbar
+            )
+            .preferredColorScheme(
+                usesThemeWindowChrome ? (windowTheme.isDark ? .dark : .light) : nil
+            )
             .onAppear(perform: configureBufferPersistence)
             .onChange(of: fileURL) {
                 configureBufferPersistence()
@@ -70,6 +93,11 @@ struct ContentView: View {
                         workspace.focusedController?.showThemePicker.toggle()
                     } label: {
                         Label("Theme", systemImage: "paintbrush")
+                            .foregroundStyle(
+                                usesThemeWindowChrome
+                                    ? windowTheme.foreground.swiftUIColor
+                                    : Color.primary
+                            )
                     }
                     .help("Change the theme of this terminal")
                     .disabled(workspace.focusedController == nil)
@@ -162,6 +190,8 @@ struct ThemePickerPopover: View {
 }
 
 struct WindowTabbingConfigurator: NSViewRepresentable {
+    let theme: TerminalTheme?
+
     func makeNSView(context: Context) -> NSView {
         let view = NSView()
         configureWindow(for: view)
@@ -178,6 +208,7 @@ struct WindowTabbingConfigurator: NSViewRepresentable {
             window.tabbingIdentifier = "TerminalDocument"
             window.tabbingMode = .preferred
             TerminalWindowSizeStore.shared.configure(window)
+            TerminalWindowAppearance.apply(theme: theme, to: window)
         }
     }
 }

--- a/Tecolot/ContentView.swift
+++ b/Tecolot/ContentView.swift
@@ -33,12 +33,6 @@ struct ContentView: View {
         workspace.focusedController?.profile.useThemeColorsForWindowChrome ?? true
     }
 
-    private var windowChromeBackground: AnyShapeStyle {
-        usesThemeWindowChrome
-            ? AnyShapeStyle(windowTheme.background.swiftUIColor)
-            : AnyShapeStyle(.bar)
-    }
-
     var body: some View {
         TerminalPaneContainer(
             workspace: workspace,
@@ -48,11 +42,6 @@ struct ContentView: View {
             .background(WindowTabbingConfigurator(
                 theme: usesThemeWindowChrome ? windowTheme : nil
             ))
-            .toolbarBackground(windowChromeBackground, for: .windowToolbar)
-            .toolbarBackgroundVisibility(
-                usesThemeWindowChrome ? .visible : .automatic,
-                for: .windowToolbar
-            )
             .preferredColorScheme(
                 usesThemeWindowChrome ? (windowTheme.isDark ? .dark : .light) : nil
             )

--- a/Tecolot/ContentView.swift
+++ b/Tecolot/ContentView.swift
@@ -25,12 +25,24 @@ struct ContentView: View {
         workspace.controllers.first
     }
 
+    /// The controller the window chrome follows. Focus is briefly nil while a
+    /// pane is torn down or before the first pane is built; falling back to the
+    /// root pane keeps the titlebar on the profile theme instead of flashing
+    /// the built-in dark fallback.
+    private var chromeController: TerminalSessionController? {
+        workspace.focusedController ?? rootController
+    }
+
     private var windowTheme: TerminalTheme {
-        workspace.focusedController?.effectiveTheme ?? .fallback
+        chromeController?.effectiveTheme ?? .fallback
     }
 
     private var usesThemeWindowChrome: Bool {
-        workspace.focusedController?.profile.useThemeColorsForWindowChrome ?? true
+        chromeController?.profile.useThemeColorsForWindowChrome ?? true
+    }
+
+    private var chromeBackgroundOpacity: Double {
+        chromeController?.effectiveBackgroundOpacity ?? 1
     }
 
     var body: some View {
@@ -40,7 +52,8 @@ struct ContentView: View {
             revision: workspace.revision
         )
             .background(WindowTabbingConfigurator(
-                theme: usesThemeWindowChrome ? windowTheme : nil
+                theme: usesThemeWindowChrome ? windowTheme : nil,
+                backgroundOpacity: chromeBackgroundOpacity
             ))
             .preferredColorScheme(
                 usesThemeWindowChrome ? (windowTheme.isDark ? .dark : .light) : nil
@@ -81,12 +94,14 @@ struct ContentView: View {
                     Button {
                         workspace.focusedController?.showThemePicker.toggle()
                     } label: {
-                        Label("Theme", systemImage: "paintbrush")
-                            .foregroundStyle(
-                                usesThemeWindowChrome
-                                    ? windowTheme.foreground.swiftUIColor
-                                    : Color.primary
-                            )
+                        // Tinting a disabled button would paint it at full
+                        // strength and hide that it is disabled.
+                        if workspace.focusedController != nil, usesThemeWindowChrome {
+                            Label("Theme", systemImage: "paintbrush")
+                                .foregroundStyle(windowTheme.foreground.swiftUIColor)
+                        } else {
+                            Label("Theme", systemImage: "paintbrush")
+                        }
                     }
                     .help("Change the theme of this terminal")
                     .disabled(workspace.focusedController == nil)
@@ -180,6 +195,7 @@ struct ThemePickerPopover: View {
 
 struct WindowTabbingConfigurator: NSViewRepresentable {
     let theme: TerminalTheme?
+    var backgroundOpacity: Double = 1
 
     func makeNSView(context: Context) -> NSView {
         let view = NSView()
@@ -197,7 +213,11 @@ struct WindowTabbingConfigurator: NSViewRepresentable {
             window.tabbingIdentifier = "TerminalDocument"
             window.tabbingMode = .preferred
             TerminalWindowSizeStore.shared.configure(window)
-            TerminalWindowAppearance.apply(theme: theme, to: window)
+            TerminalWindowAppearance.apply(
+                theme: theme,
+                backgroundOpacity: backgroundOpacity,
+                to: window
+            )
         }
     }
 }

--- a/Tecolot/Profiles/TerminalProfile.swift
+++ b/Tecolot/Profiles/TerminalProfile.swift
@@ -143,6 +143,8 @@ public struct TerminalProfile: Identifiable, Codable, Equatable, Sendable {
     /// Opacity of the default background, 0...1; values below 1 need a
     /// non-opaque host window
     public var backgroundOpacity: Double
+    /// Use the terminal theme for the macOS title bar, tabs, and toolbar controls
+    public var useThemeColorsForWindowChrome: Bool
 
     // MARK: Window
     /// Initial window width in character columns
@@ -189,6 +191,7 @@ public struct TerminalProfile: Identifiable, Codable, Equatable, Sendable {
         self.useBrightColorsForBold = defaults.useBrightColorsForBold
         self.cursorStyle = defaults.cursorStyle
         self.backgroundOpacity = defaults.backgroundOpacity
+        self.useThemeColorsForWindowChrome = defaults.useThemeColorsForWindowChrome
         self.columns = defaults.columns
         self.rows = defaults.rows
         self.scrollbackLines = defaults.scrollbackLines
@@ -212,6 +215,7 @@ public struct TerminalProfile: Identifiable, Codable, Equatable, Sendable {
     static var standardValues: (themeName: String, fontFamily: String?, fontSize: Double,
                                 fontSmoothing: Bool, useBrightColorsForBold: Bool,
                                 cursorStyle: CursorStyle, backgroundOpacity: Double,
+                                useThemeColorsForWindowChrome: Bool,
                                 columns: Int, rows: Int, scrollbackLines: Int?,
                                 titleOverride: String?, titleComponents: Set<TerminalTitleComponent>, shell: ShellCommand,
                                 whenShellExits: ShellExitBehavior, askBeforeClosing: AskBeforeClosing,
@@ -222,6 +226,7 @@ public struct TerminalProfile: Identifiable, Codable, Equatable, Sendable {
         (themeName: TerminalTheme.fallback.name, fontFamily: nil, fontSize: 12,
          fontSmoothing: true, useBrightColorsForBold: true,
          cursorStyle: .blinkBlock, backgroundOpacity: 1.0,
+         useThemeColorsForWindowChrome: true,
          columns: 80, rows: 25, scrollbackLines: 10_000,
          titleOverride: nil, titleComponents: [.activeTitle, .workingDirectory], shell: .loginShell,
          whenShellExits: .closeIfExitedCleanly, askBeforeClosing: .onlyIfProcessesRunning,
@@ -233,6 +238,7 @@ public struct TerminalProfile: Identifiable, Codable, Equatable, Sendable {
     enum CodingKeys: String, CodingKey {
         case id, name, themeName, fontFamily, fontSize, fontSmoothing
         case useBrightColorsForBold, cursorStyle, backgroundOpacity
+        case useThemeColorsForWindowChrome
         case columns, rows, scrollbackLines, titleOverride, titleComponents
         case shell, whenShellExits, askBeforeClosing
         case optionAsMetaKey, backspaceSendsControlH, keyBindings, termName, termProgram, termVersion
@@ -259,6 +265,10 @@ public struct TerminalProfile: Identifiable, Codable, Equatable, Sendable {
             self.cursorStyle = defaults.cursorStyle
         }
         self.backgroundOpacity = try c.decodeIfPresent (Double.self, forKey: .backgroundOpacity) ?? defaults.backgroundOpacity
+        self.useThemeColorsForWindowChrome = try c.decodeIfPresent(
+            Bool.self,
+            forKey: .useThemeColorsForWindowChrome
+        ) ?? defaults.useThemeColorsForWindowChrome
         self.columns = try c.decodeIfPresent (Int.self, forKey: .columns) ?? defaults.columns
         self.rows = try c.decodeIfPresent (Int.self, forKey: .rows) ?? defaults.rows
         // An explicit null means "unlimited"; only a missing key falls back to the default
@@ -299,6 +309,7 @@ public struct TerminalProfile: Identifiable, Codable, Equatable, Sendable {
         try c.encode (useBrightColorsForBold, forKey: .useBrightColorsForBold)
         try c.encode (cursorStyle.tagName, forKey: .cursorStyle)
         try c.encode (backgroundOpacity, forKey: .backgroundOpacity)
+        try c.encode(useThemeColorsForWindowChrome, forKey: .useThemeColorsForWindowChrome)
         try c.encode (columns, forKey: .columns)
         try c.encode (rows, forKey: .rows)
         // Encoded unconditionally: an explicit null means "unlimited scrollback"

--- a/Tecolot/Settings/ProfilesSettingsView.swift
+++ b/Tecolot/Settings/ProfilesSettingsView.swift
@@ -361,6 +361,12 @@ struct ProfileSettingsPage: View {
             } header: {
                 Text("Theme")
             }
+        }
+    }
+
+    @ViewBuilder
+    private var windowSettings: some View {
+        Form {
             Section {
                 Toggle(
                     "Match window chrome to theme",
@@ -371,12 +377,6 @@ struct ProfileSettingsPage: View {
             } footer: {
                 Text("Applies the theme to the title bar, tabs, and toolbar controls. Turn this off to follow the system appearance.")
             }
-        }
-    }
-
-    @ViewBuilder
-    private var windowSettings: some View {
-        Form {
             Section {
                 TextField("Columns:", value: binding(\.columns), format: .number)
                 TextField("Rows:", value: binding(\.rows), format: .number)

--- a/Tecolot/Settings/ProfilesSettingsView.swift
+++ b/Tecolot/Settings/ProfilesSettingsView.swift
@@ -361,6 +361,16 @@ struct ProfileSettingsPage: View {
             } header: {
                 Text("Theme")
             }
+            Section {
+                Toggle(
+                    "Match window chrome to theme",
+                    isOn: binding(\.useThemeColorsForWindowChrome)
+                )
+            } header: {
+                Text("Window chrome")
+            } footer: {
+                Text("Applies the theme to the title bar, tabs, and toolbar controls. Turn this off to follow the system appearance.")
+            }
         }
     }
 

--- a/Tecolot/TerminalSessionView.swift
+++ b/Tecolot/TerminalSessionView.swift
@@ -673,7 +673,9 @@ final class TerminalSessionController: NSObject, LocalProcessTerminalViewDelegat
             object: window,
             queue: .main
         ) { [weak self, weak window] _ in
-            Task { @MainActor [weak self, weak window] in
+            // didUpdate posts on nearly every pass of the event loop, once per
+            // pane. Test the responder before spending a task on it.
+            MainActor.assumeIsolated {
                 guard let self, let window, window.firstResponder === self.terminal else { return }
                 self.didBecomeFocused()
             }

--- a/Tecolot/TerminalSessionView.swift
+++ b/Tecolot/TerminalSessionView.swift
@@ -660,16 +660,23 @@ final class TerminalSessionController: NSObject, LocalProcessTerminalViewDelegat
             forName: NSWindow.didBecomeKeyNotification,
             object: window,
             queue: .main
-        ) { [weak self] _ in
-            self?.setHasActivity(false)
+        ) { [weak self, weak window] _ in
+            Task { @MainActor [weak self, weak window] in
+                self?.setHasActivity(false)
+                if let window {
+                    TerminalWindowAppearance.scheduleChromeRefresh(for: window)
+                }
+            }
         }
         windowUpdateObserver = NotificationCenter.default.addObserver(
             forName: NSWindow.didUpdateNotification,
             object: window,
             queue: .main
         ) { [weak self, weak window] _ in
-            guard let self, let window, window.firstResponder === self.terminal else { return }
-            self.didBecomeFocused()
+            Task { @MainActor [weak self, weak window] in
+                guard let self, let window, window.firstResponder === self.terminal else { return }
+                self.didBecomeFocused()
+            }
         }
         if window.isKeyWindow {
             setHasActivity(false)

--- a/Tecolot/TerminalWindowAppearance.swift
+++ b/Tecolot/TerminalWindowAppearance.swift
@@ -1,0 +1,50 @@
+//
+//  TerminalWindowAppearance.swift
+//  Tecolot
+//
+
+import AppKit
+
+@MainActor
+enum TerminalWindowAppearance {
+    static func apply(theme: TerminalTheme?, to window: NSWindow) {
+        window.appearance = theme.flatMap {
+            NSAppearance(named: $0.isDark ? .darkAqua : .aqua)
+        }
+        scheduleChromeRefresh(for: window)
+    }
+
+    static func scheduleChromeRefresh(for window: NSWindow) {
+        // AppKit moves and reuses the native tab bar while selecting a tab.
+        // Refresh on the next turn, after that view hierarchy has settled.
+        DispatchQueue.main.async { [weak window] in
+            guard let window else { return }
+            window.toolbar?.validateVisibleItems()
+            guard let frameView = window.contentView?.superview else { return }
+            let chromeView = firstDescendant(named: "NSTitlebarContainerView", in: frameView)
+                ?? frameView
+            invalidate(chromeView)
+            chromeView.layoutSubtreeIfNeeded()
+            chromeView.displayIfNeeded()
+        }
+    }
+
+    private static func invalidate(_ view: NSView) {
+        view.needsLayout = true
+        view.needsDisplay = true
+        view.layer?.setNeedsDisplay()
+        view.subviews.forEach(invalidate)
+    }
+
+    private static func firstDescendant(named className: String, in view: NSView) -> NSView? {
+        if view.className == className {
+            return view
+        }
+        for subview in view.subviews {
+            if let match = firstDescendant(named: className, in: subview) {
+                return match
+            }
+        }
+        return nil
+    }
+}

--- a/Tecolot/TerminalWindowAppearance.swift
+++ b/Tecolot/TerminalWindowAppearance.swift
@@ -11,22 +11,38 @@ enum TerminalWindowAppearance {
         keyOptions: .weakMemory,
         valueOptions: .strongMemory
     )
+    /// Windows with a refresh already queued for the next turn of the main
+    /// queue. Every pane of a split observes the same window, so without this
+    /// an N-pane window would walk the titlebar tree N times per activation.
+    private static let pendingRefreshes = NSHashTable<NSWindow>.weakObjects()
+    /// Windows whose chrome already shows the stored state. A window is absent
+    /// while its titlebar is out of reach (it is not built yet, or the window
+    /// is in full screen), which keeps the next update from being skipped.
+    private static let settledWindows = NSHashTable<NSWindow>.weakObjects()
 
-    static func apply(theme: TerminalTheme?, to window: NSWindow) {
+    static func apply(theme: TerminalTheme?, backgroundOpacity: Double = 1, to window: NSWindow) {
+        let color = theme.map { theme -> NSColor in
+            let background = theme.background
+            return NSColor(
+                srgbRed: CGFloat(background.red) / 65_535,
+                green: CGFloat(background.green) / 65_535,
+                blue: CGFloat(background.blue) / 65_535,
+                // The titlebar is folded into the translucent content region,
+                // so an opaque band over a translucent terminal would not match.
+                alpha: CGFloat(backgroundOpacity)
+            )
+        }
+        // SwiftUI reapplies this on every update of the terminal view; a
+        // repeated refresh would relayout the whole titlebar for nothing.
+        guard color != themeBackgrounds.object(forKey: window)
+                || !settledWindows.contains(window)
+        else { return }
+
         window.appearance = theme.flatMap {
             NSAppearance(named: $0.isDark ? .darkAqua : .aqua)
         }
-        if let theme {
-            let background = theme.background
-            themeBackgrounds.setObject(
-                NSColor(
-                    srgbRed: CGFloat(background.red) / 65_535,
-                    green: CGFloat(background.green) / 65_535,
-                    blue: CGFloat(background.blue) / 65_535,
-                    alpha: 1
-                ),
-                forKey: window
-            )
+        if let color {
+            themeBackgrounds.setObject(color, forKey: window)
         } else {
             themeBackgrounds.removeObject(forKey: window)
         }
@@ -34,15 +50,29 @@ enum TerminalWindowAppearance {
     }
 
     static func scheduleChromeRefresh(for window: NSWindow) {
+        guard !pendingRefreshes.contains(window) else { return }
+        pendingRefreshes.add(window)
         // AppKit moves and reuses the native tab bar while selecting a tab.
         // Refresh on the next turn, after that view hierarchy has settled.
         DispatchQueue.main.async { [weak window] in
             guard let window else { return }
+            pendingRefreshes.remove(window)
             window.toolbar?.validateVisibleItems()
-            guard let frameView = window.contentView?.superview else { return }
-            let chromeView = firstDescendant(named: "NSTitlebarContainerView", in: frameView)
-                ?? frameView
-            applyBackground(themeBackgrounds.object(forKey: window), to: chromeView)
+            guard let frameView = window.contentView?.superview,
+                  let chromeView = firstDescendant(named: "NSTitlebarContainerView", in: frameView)
+            else {
+                // In full screen AppKit hosts the titlebar in a separate
+                // window. There is no chrome to color here; a later refresh
+                // reapplies the current state when it comes back.
+                settledWindows.remove(window)
+                return
+            }
+            let settled = applyBackground(themeBackgrounds.object(forKey: window), to: chromeView)
+            if settled {
+                settledWindows.add(window)
+            } else {
+                settledWindows.remove(window)
+            }
             invalidate(chromeView)
             chromeView.layoutSubtreeIfNeeded()
             chromeView.displayIfNeeded()
@@ -53,18 +83,23 @@ enum TerminalWindowAppearance {
     /// background over it. This preserves the native, full-height drag region
     /// and follows Ghostty's MIT-licensed transparent-titlebar implementation:
     /// https://github.com/ghostty-org/ghostty/blob/main/macos/Sources/Features/Terminal/Window%20Styles/TransparentTitlebarTerminalWindow.swift
-    private static func applyBackground(_ color: NSColor?, to chromeView: NSView) {
+    /// Returns whether the chrome now shows `color`.
+    @discardableResult
+    private static func applyBackground(_ color: NSColor?, to chromeView: NSView) -> Bool {
         if #available(macOS 26.0, *) {
-            guard let titlebarView = firstDescendant(named: "NSTitlebarView", in: chromeView)
-            else { return }
-            titlebarView.wantsLayer = color != nil
-            titlebarView.layer?.backgroundColor = color?.cgColor
-            firstDescendant(named: "NSTitlebarBackgroundView", in: chromeView)?.isHidden =
-                color != nil
+            let backgroundView = firstDescendant(named: "NSTitlebarBackgroundView", in: chromeView)
+            let titlebarView = firstDescendant(named: "NSTitlebarView", in: chromeView)
+            titlebarView?.wantsLayer = color != nil
+            titlebarView?.layer?.backgroundColor = color?.cgColor
+            // Hide the native background only once the themed layer replaces
+            // it, and always restore it when the theme is removed.
+            backgroundView?.isHidden = color != nil && titlebarView != nil
+            return titlebarView != nil
         } else {
             chromeView.wantsLayer = color != nil
             chromeView.layer?.backgroundColor = color?.cgColor
             chromeView.window?.titlebarAppearsTransparent = color != nil
+            return true
         }
     }
 

--- a/Tecolot/TerminalWindowAppearance.swift
+++ b/Tecolot/TerminalWindowAppearance.swift
@@ -7,9 +7,28 @@ import AppKit
 
 @MainActor
 enum TerminalWindowAppearance {
+    private static let themeBackgrounds = NSMapTable<NSWindow, NSColor>(
+        keyOptions: .weakMemory,
+        valueOptions: .strongMemory
+    )
+
     static func apply(theme: TerminalTheme?, to window: NSWindow) {
         window.appearance = theme.flatMap {
             NSAppearance(named: $0.isDark ? .darkAqua : .aqua)
+        }
+        if let theme {
+            let background = theme.background
+            themeBackgrounds.setObject(
+                NSColor(
+                    srgbRed: CGFloat(background.red) / 65_535,
+                    green: CGFloat(background.green) / 65_535,
+                    blue: CGFloat(background.blue) / 65_535,
+                    alpha: 1
+                ),
+                forKey: window
+            )
+        } else {
+            themeBackgrounds.removeObject(forKey: window)
         }
         scheduleChromeRefresh(for: window)
     }
@@ -23,9 +42,29 @@ enum TerminalWindowAppearance {
             guard let frameView = window.contentView?.superview else { return }
             let chromeView = firstDescendant(named: "NSTitlebarContainerView", in: frameView)
                 ?? frameView
+            applyBackground(themeBackgrounds.object(forKey: window), to: chromeView)
             invalidate(chromeView)
             chromeView.layoutSubtreeIfNeeded()
             chromeView.displayIfNeeded()
+        }
+    }
+
+    /// Colors AppKit's native titlebar instead of placing a SwiftUI toolbar
+    /// background over it. This preserves the native, full-height drag region
+    /// and follows Ghostty's MIT-licensed transparent-titlebar implementation:
+    /// https://github.com/ghostty-org/ghostty/blob/main/macos/Sources/Features/Terminal/Window%20Styles/TransparentTitlebarTerminalWindow.swift
+    private static func applyBackground(_ color: NSColor?, to chromeView: NSView) {
+        if #available(macOS 26.0, *) {
+            guard let titlebarView = firstDescendant(named: "NSTitlebarView", in: chromeView)
+            else { return }
+            titlebarView.wantsLayer = color != nil
+            titlebarView.layer?.backgroundColor = color?.cgColor
+            firstDescendant(named: "NSTitlebarBackgroundView", in: chromeView)?.isHidden =
+                color != nil
+        } else {
+            chromeView.wantsLayer = color != nil
+            chromeView.layer?.backgroundColor = color?.cgColor
+            chromeView.window?.titlebarAppearsTransparent = color != nil
         }
     }
 

--- a/TecolotTests/TerminalProfilesTests.swift
+++ b/TecolotTests/TerminalProfilesTests.swift
@@ -349,6 +349,7 @@ final class ProfileStoreTests {
         var extra = TerminalProfile (name: "Servers")
         extra.themeName = "Nord"
         extra.fontSize = 14
+        extra.useThemeColorsForWindowChrome = false
         try store.add (extra)
         #expect (store.profiles.count == 1)
         #expect (store.defaultProfileID == extra.id)
@@ -368,6 +369,7 @@ final class ProfileStoreTests {
         #expect (reloaded.defaultProfile.name == "Servers")
         #expect (reloaded.profile (named: "Workers") != nil)
         #expect (reloaded.profile (named: "Servers")?.themeName == "Nord")
+        #expect(reloaded.profile(named: "Servers")?.useThemeColorsForWindowChrome == false)
 
         try store.delete (copy.id)
         #expect (store.profiles.count == 1)
@@ -487,6 +489,7 @@ final class ProfileStoreTests {
         #expect(profile.titleComponents == [.activeTitle, .workingDirectory])
         #expect(profile.termProgram == "ghostty")
         #expect(profile.termVersion == "1.3.1")
+        #expect(profile.useThemeColorsForWindowChrome)
     }
 
     @Test func futureProfileRemainsUntouchedAndIsReported() throws {

--- a/TecolotTests/TerminalWindowAppearanceTests.swift
+++ b/TecolotTests/TerminalWindowAppearanceTests.swift
@@ -1,0 +1,42 @@
+import AppKit
+import Testing
+@testable import Tecolot
+
+@MainActor
+struct TerminalWindowAppearanceTests {
+    @Test func themedChromeColorsNativeTitlebarWithoutAddingDragOverlay() async throws {
+        let window = NSWindow(
+            contentRect: NSRect(x: 100, y: 100, width: 800, height: 500),
+            styleMask: [.titled, .closable, .resizable],
+            backing: .buffered,
+            defer: false
+        )
+        window.toolbar = NSToolbar(identifier: "TestToolbar")
+        window.contentView = NSView()
+        window.layoutIfNeeded()
+
+        TerminalWindowAppearance.apply(theme: .fallback, to: window)
+        await nextMainQueueTurn()
+
+        let frameView = try #require(window.contentView?.superview)
+        let titlebarView = try #require(descendants(in: frameView).first {
+            $0.className == "NSTitlebarView"
+        })
+        #expect(titlebarView.layer?.backgroundColor != nil)
+        #expect(!descendants(in: frameView).contains {
+            $0.identifier?.rawValue == "TerminalWindowDragHandle"
+        })
+    }
+
+    private func nextMainQueueTurn() async {
+        await withCheckedContinuation { continuation in
+            DispatchQueue.main.async {
+                continuation.resume()
+            }
+        }
+    }
+
+    private func descendants(in view: NSView) -> [NSView] {
+        [view] + view.subviews.flatMap(descendants)
+    }
+}

--- a/TecolotTests/TerminalWindowAppearanceTests.swift
+++ b/TecolotTests/TerminalWindowAppearanceTests.swift
@@ -5,6 +5,46 @@ import Testing
 @MainActor
 struct TerminalWindowAppearanceTests {
     @Test func themedChromeColorsNativeTitlebarWithoutAddingDragOverlay() async throws {
+        let window = makeWindow()
+
+        TerminalWindowAppearance.apply(theme: .fallback, to: window)
+        await nextMainQueueTurn()
+
+        let frameView = try #require(window.contentView?.superview)
+        #expect(try themedChromeView(in: frameView).layer?.backgroundColor != nil)
+        #expect(!descendants(in: frameView).contains {
+            $0.identifier?.rawValue == "TerminalWindowDragHandle"
+        })
+    }
+
+    @Test func removingTheThemeRestoresTheNativeTitlebarBackground() async throws {
+        let window = makeWindow()
+
+        TerminalWindowAppearance.apply(theme: .fallback, to: window)
+        await nextMainQueueTurn()
+        TerminalWindowAppearance.apply(theme: nil, to: window)
+        await nextMainQueueTurn()
+
+        let frameView = try #require(window.contentView?.superview)
+        #expect(try themedChromeView(in: frameView).layer?.backgroundColor == nil)
+        #expect(!descendants(in: frameView).contains {
+            $0.className == "NSTitlebarBackgroundView" && $0.isHidden
+        })
+    }
+
+    /// The titlebar view that `applyBackground` paints, which differs by OS:
+    /// macOS 26 colors the inner `NSTitlebarView`, earlier releases color the
+    /// container and make the native titlebar transparent.
+    private func themedChromeView(in frameView: NSView) throws -> NSView {
+        let className = if #available(macOS 26.0, *) {
+            "NSTitlebarView"
+        } else {
+            "NSTitlebarContainerView"
+        }
+        return try #require(descendants(in: frameView).first { $0.className == className })
+    }
+
+    private func makeWindow() -> NSWindow {
         let window = NSWindow(
             contentRect: NSRect(x: 100, y: 100, width: 800, height: 500),
             styleMask: [.titled, .closable, .resizable],
@@ -14,18 +54,7 @@ struct TerminalWindowAppearanceTests {
         window.toolbar = NSToolbar(identifier: "TestToolbar")
         window.contentView = NSView()
         window.layoutIfNeeded()
-
-        TerminalWindowAppearance.apply(theme: .fallback, to: window)
-        await nextMainQueueTurn()
-
-        let frameView = try #require(window.contentView?.superview)
-        let titlebarView = try #require(descendants(in: frameView).first {
-            $0.className == "NSTitlebarView"
-        })
-        #expect(titlebarView.layer?.backgroundColor != nil)
-        #expect(!descendants(in: frameView).contains {
-            $0.identifier?.rawValue == "TerminalWindowDragHandle"
-        })
+        return window
     }
 
     private func nextMainQueueTurn() async {


### PR DESCRIPTION
I like it when the terminal theme affects the entire terminal window. I missed this feature from Ghostty. This PR provides a new setting to enable/disable this feature. It is enabled by default and is a per-profile setting. It properly accounts for light/dark themes since tinting changes based on that.

<img width="800" height="502" alt="CleanShot 2026-09-01 at 21 16 10" src="https://github.com/user-attachments/assets/3fb8162b-6b07-4d2a-acd3-e5b40e00b550" />

*LLM Disclaimer: I used Sol 5.6 with codex to write this code.*