### PR TITLE
feat: setting to hide cursor while typing

### DIFF
--- a/Tecolot/Profiles/TerminalProfile.swift
+++ b/Tecolot/Profiles/TerminalProfile.swift
@@ -166,6 +166,7 @@ public struct TerminalProfile: Identifiable, Codable, Equatable, Sendable {
     // MARK: Keyboard
     public var optionAsMetaKey: Bool
     public var backspaceSendsControlH: Bool
+    public var hidePointerWhileTyping: Bool
     public var keyBindings: [TerminalKeyBinding]
 
     // MARK: Advanced
@@ -202,6 +203,7 @@ public struct TerminalProfile: Identifiable, Codable, Equatable, Sendable {
         self.askBeforeClosing = defaults.askBeforeClosing
         self.optionAsMetaKey = defaults.optionAsMetaKey
         self.backspaceSendsControlH = defaults.backspaceSendsControlH
+        self.hidePointerWhileTyping = defaults.hidePointerWhileTyping
         self.keyBindings = defaults.keyBindings
         self.termName = defaults.termName
         self.termProgram = defaults.termProgram
@@ -219,7 +221,8 @@ public struct TerminalProfile: Identifiable, Codable, Equatable, Sendable {
                                 columns: Int, rows: Int, scrollbackLines: Int?,
                                 titleOverride: String?, titleComponents: Set<TerminalTitleComponent>, shell: ShellCommand,
                                 whenShellExits: ShellExitBehavior, askBeforeClosing: AskBeforeClosing,
-                                optionAsMetaKey: Bool, backspaceSendsControlH: Bool, termName: String,
+                                optionAsMetaKey: Bool, backspaceSendsControlH: Bool,
+                                hidePointerWhileTyping: Bool, termName: String,
                                 termProgram: String, termVersion: String,
                                 environmentVariables: [TerminalEnvironmentVariable], bellStyle: BellStyle,
                                 keyBindings: [TerminalKeyBinding]) {
@@ -230,7 +233,8 @@ public struct TerminalProfile: Identifiable, Codable, Equatable, Sendable {
          columns: 80, rows: 25, scrollbackLines: 10_000,
          titleOverride: nil, titleComponents: [.activeTitle, .workingDirectory], shell: .loginShell,
          whenShellExits: .closeIfExitedCleanly, askBeforeClosing: .onlyIfProcessesRunning,
-         optionAsMetaKey: true, backspaceSendsControlH: false, termName: "xterm-256color",
+         optionAsMetaKey: true, backspaceSendsControlH: false, hidePointerWhileTyping: true,
+         termName: "xterm-256color",
          termProgram: "ghostty", termVersion: "1.3.1",
          environmentVariables: [], bellStyle: .sound, keyBindings: [])
     }
@@ -241,7 +245,8 @@ public struct TerminalProfile: Identifiable, Codable, Equatable, Sendable {
         case useThemeColorsForWindowChrome
         case columns, rows, scrollbackLines, titleOverride, titleComponents
         case shell, whenShellExits, askBeforeClosing
-        case optionAsMetaKey, backspaceSendsControlH, keyBindings, termName, termProgram, termVersion
+        case optionAsMetaKey, backspaceSendsControlH, hidePointerWhileTyping, keyBindings
+        case termName, termProgram, termVersion
         case environmentVariables, bellStyle
     }
 
@@ -284,6 +289,10 @@ public struct TerminalProfile: Identifiable, Codable, Equatable, Sendable {
         self.askBeforeClosing = try c.decodeIfPresent (AskBeforeClosing.self, forKey: .askBeforeClosing) ?? defaults.askBeforeClosing
         self.optionAsMetaKey = try c.decodeIfPresent (Bool.self, forKey: .optionAsMetaKey) ?? defaults.optionAsMetaKey
         self.backspaceSendsControlH = try c.decodeIfPresent (Bool.self, forKey: .backspaceSendsControlH) ?? defaults.backspaceSendsControlH
+        self.hidePointerWhileTyping = try c.decodeIfPresent(
+            Bool.self,
+            forKey: .hidePointerWhileTyping
+        ) ?? defaults.hidePointerWhileTyping
         self.keyBindings = try c.decodeIfPresent ([TerminalKeyBinding].self, forKey: .keyBindings) ?? defaults.keyBindings
         self.termName = try c.decodeIfPresent (String.self, forKey: .termName) ?? defaults.termName
         self.termProgram = try c.decodeIfPresent(String.self, forKey: .termProgram) ?? defaults.termProgram
@@ -321,6 +330,7 @@ public struct TerminalProfile: Identifiable, Codable, Equatable, Sendable {
         try c.encode (askBeforeClosing, forKey: .askBeforeClosing)
         try c.encode (optionAsMetaKey, forKey: .optionAsMetaKey)
         try c.encode (backspaceSendsControlH, forKey: .backspaceSendsControlH)
+        try c.encode(hidePointerWhileTyping, forKey: .hidePointerWhileTyping)
         try c.encode (keyBindings, forKey: .keyBindings)
         try c.encode (termName, forKey: .termName)
         try c.encode(termProgram, forKey: .termProgram)

--- a/Tecolot/Settings/ProfilesSettingsView.swift
+++ b/Tecolot/Settings/ProfilesSettingsView.swift
@@ -452,6 +452,7 @@ struct ProfileSettingsPage: View {
             Section {
                 Toggle("Use Option as Meta key", isOn: binding(\.optionAsMetaKey))
                 Toggle("Delete sends Control-H", isOn: binding(\.backspaceSendsControlH))
+                Toggle("Hide pointer while typing", isOn: binding(\.hidePointerWhileTyping))
             }
             Section("Key Mappings"){
                 TerminalKeyBindingsEditor(profile: profile, update: updateIgnoringResult)

--- a/Tecolot/TerminalSessionView.swift
+++ b/Tecolot/TerminalSessionView.swift
@@ -511,6 +511,10 @@ final class TerminalSessionController: NSObject, LocalProcessTerminalViewDelegat
             return false
         }
 
+        if profile.hidePointerWhileTyping {
+            NSCursor.setHiddenUntilMouseMoves(true)
+        }
+
         let key = normalizedKey(for: event)
         let modifiers = terminalModifiers(for: event.modifierFlags)
         guard let keyBinding = profile.keyBindings.first(where: {

--- a/TecolotTests/TerminalProfilesTests.swift
+++ b/TecolotTests/TerminalProfilesTests.swift
@@ -441,6 +441,17 @@ final class ProfileStoreTests {
         #expect(reloaded.defaultProfile.keyBindings == profile.keyBindings)
     }
 
+    @Test func hidePointerWhileTypingSurvivesRoundTrip() throws {
+        let (store, dir) = try makeStore()
+        defer { try? FileManager.default.removeItem(at: dir) }
+        var profile = store.defaultProfile
+        profile.hidePointerWhileTyping = false
+        try store.update(profile)
+
+        let reloaded = try ProfileStore(directory: dir)
+        #expect(!reloaded.defaultProfile.hidePointerWhileTyping)
+    }
+
     @Test func repairsDuplicateNamesWithoutDeletingProfiles () throws {
         let dir = FileManager.default.temporaryDirectory
             .appendingPathComponent("profile-store-duplicate-tests-\(UUID().uuidString)")
@@ -501,6 +512,7 @@ final class ProfileStoreTests {
         #expect(profile.termProgram == "ghostty")
         #expect(profile.termVersion == "1.3.1")
         #expect(profile.useThemeColorsForWindowChrome)
+        #expect(profile.hidePointerWhileTyping)
     }
 
     @Test func futureProfileRemainsUntouchedAndIsReported() throws {


### PR DESCRIPTION
A new profile specific setting to hide the cursor while typing. It currently defaults to true.

Here's a demo:
<img width="800" height="607" alt="CleanShot 2026-09-03 at 09 40 33" src="https://github.com/user-attachments/assets/ba4a396b-1766-4c18-9243-e47584d02272" />

*LLM Disclosure: Codex wrote this with 4.6 Sol*