### PR TITLE
feat: new settings to adjust terminal padding per edge

### DIFF
--- a/Tecolot/ProfileCommands.swift
+++ b/Tecolot/ProfileCommands.swift
@@ -31,7 +31,8 @@ enum TerminalProfileWindowSizer {
             assert(didClose, "The terminal sizing view did not release its UI resources")
         }
         return TerminalSessionContainerView.contentSize(
-            forTerminalSize: terminal.getOptimalFrameSize().size
+            forTerminalSize: terminal.getOptimalFrameSize().size,
+            padding: profile.terminalPadding
         )
     }
 }

--- a/Tecolot/Profiles/ProfileStore.swift
+++ b/Tecolot/Profiles/ProfileStore.swift
@@ -26,6 +26,14 @@ private struct ProfileDocumentMigrator: VersionedDocumentMigrator {
               profile.fontSize > 0,
               profile.backgroundOpacity.isFinite,
               (0...1).contains(profile.backgroundOpacity),
+              profile.terminalPadding.top.isFinite,
+              profile.terminalPadding.top >= 0,
+              profile.terminalPadding.left.isFinite,
+              profile.terminalPadding.left >= 0,
+              profile.terminalPadding.bottom.isFinite,
+              profile.terminalPadding.bottom >= 0,
+              profile.terminalPadding.right.isFinite,
+              profile.terminalPadding.right >= 0,
               profile.columns > 0,
               profile.rows > 0 else {
             throw VersionedPersistenceError.invalidDocument("The profile contains invalid values.")

--- a/Tecolot/Profiles/TerminalProfile.swift
+++ b/Tecolot/Profiles/TerminalProfile.swift
@@ -122,6 +122,28 @@ public struct TerminalKeyBinding: Identifiable, Codable, Equatable, Sendable {
     }
 }
 
+/// Space, in points, between the terminal grid and each edge of its pane.
+public struct TerminalViewPadding: Codable, Equatable, Sendable {
+    public var top: Double
+    public var left: Double
+    public var bottom: Double
+    public var right: Double
+
+    public init(top: Double, left: Double, bottom: Double, right: Double) {
+        self.top = top
+        self.left = left
+        self.bottom = bottom
+        self.right = right
+    }
+
+    public static let standard = TerminalViewPadding(
+        top: 2,
+        left: 2,
+        bottom: 2,
+        right: 2
+    )
+}
+
 public struct TerminalProfile: Identifiable, Codable, Equatable, Sendable {
     public var id: UUID
     /// Display name, unique within a store
@@ -145,6 +167,8 @@ public struct TerminalProfile: Identifiable, Codable, Equatable, Sendable {
     public var backgroundOpacity: Double
     /// Use the terminal theme for the macOS title bar, tabs, and toolbar controls
     public var useThemeColorsForWindowChrome: Bool
+    /// Space between the terminal grid and each edge of its pane
+    public var terminalPadding: TerminalViewPadding
 
     // MARK: Window
     /// Initial window width in character columns
@@ -193,6 +217,7 @@ public struct TerminalProfile: Identifiable, Codable, Equatable, Sendable {
         self.cursorStyle = defaults.cursorStyle
         self.backgroundOpacity = defaults.backgroundOpacity
         self.useThemeColorsForWindowChrome = defaults.useThemeColorsForWindowChrome
+        self.terminalPadding = defaults.terminalPadding
         self.columns = defaults.columns
         self.rows = defaults.rows
         self.scrollbackLines = defaults.scrollbackLines
@@ -218,6 +243,7 @@ public struct TerminalProfile: Identifiable, Codable, Equatable, Sendable {
                                 fontSmoothing: Bool, useBrightColorsForBold: Bool,
                                 cursorStyle: CursorStyle, backgroundOpacity: Double,
                                 useThemeColorsForWindowChrome: Bool,
+                                terminalPadding: TerminalViewPadding,
                                 columns: Int, rows: Int, scrollbackLines: Int?,
                                 titleOverride: String?, titleComponents: Set<TerminalTitleComponent>, shell: ShellCommand,
                                 whenShellExits: ShellExitBehavior, askBeforeClosing: AskBeforeClosing,
@@ -230,6 +256,7 @@ public struct TerminalProfile: Identifiable, Codable, Equatable, Sendable {
          fontSmoothing: true, useBrightColorsForBold: true,
          cursorStyle: .blinkBlock, backgroundOpacity: 1.0,
          useThemeColorsForWindowChrome: true,
+         terminalPadding: .standard,
          columns: 80, rows: 25, scrollbackLines: 10_000,
          titleOverride: nil, titleComponents: [.activeTitle, .workingDirectory], shell: .loginShell,
          whenShellExits: .closeIfExitedCleanly, askBeforeClosing: .onlyIfProcessesRunning,
@@ -242,7 +269,7 @@ public struct TerminalProfile: Identifiable, Codable, Equatable, Sendable {
     enum CodingKeys: String, CodingKey {
         case id, name, themeName, fontFamily, fontSize, fontSmoothing
         case useBrightColorsForBold, cursorStyle, backgroundOpacity
-        case useThemeColorsForWindowChrome
+        case useThemeColorsForWindowChrome, terminalPadding
         case columns, rows, scrollbackLines, titleOverride, titleComponents
         case shell, whenShellExits, askBeforeClosing
         case optionAsMetaKey, backspaceSendsControlH, hidePointerWhileTyping, keyBindings
@@ -274,6 +301,10 @@ public struct TerminalProfile: Identifiable, Codable, Equatable, Sendable {
             Bool.self,
             forKey: .useThemeColorsForWindowChrome
         ) ?? defaults.useThemeColorsForWindowChrome
+        self.terminalPadding = try c.decodeIfPresent(
+            TerminalViewPadding.self,
+            forKey: .terminalPadding
+        ) ?? defaults.terminalPadding
         self.columns = try c.decodeIfPresent (Int.self, forKey: .columns) ?? defaults.columns
         self.rows = try c.decodeIfPresent (Int.self, forKey: .rows) ?? defaults.rows
         // An explicit null means "unlimited"; only a missing key falls back to the default
@@ -319,6 +350,7 @@ public struct TerminalProfile: Identifiable, Codable, Equatable, Sendable {
         try c.encode (cursorStyle.tagName, forKey: .cursorStyle)
         try c.encode (backgroundOpacity, forKey: .backgroundOpacity)
         try c.encode(useThemeColorsForWindowChrome, forKey: .useThemeColorsForWindowChrome)
+        try c.encode(terminalPadding, forKey: .terminalPadding)
         try c.encode (columns, forKey: .columns)
         try c.encode (rows, forKey: .rows)
         // Encoded unconditionally: an explicit null means "unlimited scrollback"

--- a/Tecolot/Settings/ProfilesSettingsView.swift
+++ b/Tecolot/Settings/ProfilesSettingsView.swift
@@ -398,6 +398,32 @@ struct ProfileSettingsPage: View {
                     ), format: .number)
                 }
             }
+            Section {
+                TextField(
+                    "Top:",
+                    value: nonnegativeBinding(\.terminalPadding.top),
+                    format: .number
+                )
+                TextField(
+                    "Left:",
+                    value: nonnegativeBinding(\.terminalPadding.left),
+                    format: .number
+                )
+                TextField(
+                    "Bottom:",
+                    value: nonnegativeBinding(\.terminalPadding.bottom),
+                    format: .number
+                )
+                TextField(
+                    "Right:",
+                    value: nonnegativeBinding(\.terminalPadding.right),
+                    format: .number
+                )
+            } header: {
+                Text("Terminal padding")
+            } footer: {
+                Text("Padding is measured in points and applies to each terminal pane.")
+            }
             Section("Title") {
                 TextField("Custom title:", text: Binding(
                     get: { profile.titleOverride ?? "" },
@@ -419,6 +445,17 @@ struct ProfileSettingsPage: View {
                 }
             }
         }
+    }
+
+    private func nonnegativeBinding(
+        _ keyPath: WritableKeyPath<TerminalProfile, Double>
+    ) -> Binding<Double> {
+        Binding(
+            get: { profile[keyPath: keyPath] },
+            set: { newValue in
+                update { $0[keyPath: keyPath] = max(0, newValue) }
+            }
+        )
     }
 
     @ViewBuilder

--- a/Tecolot/TerminalPaneWorkspace.swift
+++ b/Tecolot/TerminalPaneWorkspace.swift
@@ -351,7 +351,8 @@ final class TerminalPaneHostView: NSView {
             // The container supplies the terminal's Auto Layout constraints.
             // NSSplitView must size the container, not the terminal itself.
             let view = TerminalSessionContainerView(
-                terminal: controller.makeTerminalView(document: document)
+                terminal: controller.makeTerminalView(document: document),
+                padding: controller.profile.terminalPadding
             )
             paneViews[controller.id] = view
             return view

--- a/Tecolot/TerminalSessionView.swift
+++ b/Tecolot/TerminalSessionView.swift
@@ -154,7 +154,10 @@ final class TerminalSessionController: NSObject, LocalProcessTerminalViewDelegat
                              themeStore: AppModel.shared.themes,
                              sessionThemeOverride: themeOverride,
                              to: terminal)
-        (terminal.superview as? TerminalSessionContainerView)?.updatePaddingColor()
+        if let container = terminal.superview as? TerminalSessionContainerView {
+            container.updatePadding(profile.terminalPadding)
+            container.updatePaddingColor()
+        }
         terminal.requestRedraw()
         if effectiveBackgroundOpacity >= 1.0 {
             updateWindowTransparency()
@@ -900,14 +903,13 @@ final class TerminalSessionController: NSObject, LocalProcessTerminalViewDelegat
 }
 
 final class TerminalSessionContainerView: NSView {
-    // Ghostty uses two points of window padding by default, on all four sides.
-    // The top strip also keeps the OSC 9;4 progress bar off the tab bar.
-    private static let padding: CGFloat = 2
-
-    static func contentSize(forTerminalSize terminalSize: NSSize) -> NSSize {
+    static func contentSize(
+        forTerminalSize terminalSize: NSSize,
+        padding: TerminalViewPadding
+    ) -> NSSize {
         NSSize(
-            width: terminalSize.width + padding * 2,
-            height: terminalSize.height + padding
+            width: terminalSize.width + CGFloat(padding.left + padding.right),
+            height: terminalSize.height + CGFloat(padding.top + padding.bottom)
         )
     }
 
@@ -917,11 +919,17 @@ final class TerminalSessionContainerView: NSView {
     private let rightPaddingView = NSView()
     private let bottomPaddingView = NSView()
     private let resizeFeedbackView = TerminalResizeFeedbackView()
+    private var topPaddingConstraint: NSLayoutConstraint!
+    private var leadingPaddingConstraint: NSLayoutConstraint!
+    private var bottomPaddingConstraint: NSLayoutConstraint!
+    private var trailingPaddingConstraint: NSLayoutConstraint!
     private var resizeObservers = [NSObjectProtocol]()
     private var isShowingResizeFeedback = false
+    private(set) var terminalPadding: TerminalViewPadding
 
-    init(terminal: LocalProcessTerminalView) {
+    init(terminal: LocalProcessTerminalView, padding: TerminalViewPadding) {
         self.terminal = terminal
+        self.terminalPadding = padding
         super.init(frame: .zero)
 
         terminal.translatesAutoresizingMaskIntoConstraints = false
@@ -935,6 +943,18 @@ final class TerminalSessionContainerView: NSView {
         addSubview(terminal)
         resizeFeedbackView.translatesAutoresizingMaskIntoConstraints = false
         addSubview(resizeFeedbackView)
+        topPaddingConstraint = topPaddingView.heightAnchor.constraint(
+            equalToConstant: CGFloat(padding.top)
+        )
+        leadingPaddingConstraint = leftPaddingView.widthAnchor.constraint(
+            equalToConstant: CGFloat(padding.left)
+        )
+        bottomPaddingConstraint = bottomPaddingView.heightAnchor.constraint(
+            equalToConstant: CGFloat(padding.bottom)
+        )
+        trailingPaddingConstraint = rightPaddingView.widthAnchor.constraint(
+            equalToConstant: CGFloat(padding.right)
+        )
         NSLayoutConstraint.activate([
             terminal.topAnchor.constraint(equalTo: topPaddingView.bottomAnchor),
             terminal.leadingAnchor.constraint(equalTo: leftPaddingView.trailingAnchor),
@@ -944,22 +964,22 @@ final class TerminalSessionContainerView: NSView {
             topPaddingView.topAnchor.constraint(equalTo: topAnchor),
             topPaddingView.leadingAnchor.constraint(equalTo: leadingAnchor),
             topPaddingView.trailingAnchor.constraint(equalTo: trailingAnchor),
-            topPaddingView.heightAnchor.constraint(equalToConstant: Self.padding),
+            topPaddingConstraint,
 
             leftPaddingView.topAnchor.constraint(equalTo: topPaddingView.bottomAnchor),
             leftPaddingView.leadingAnchor.constraint(equalTo: leadingAnchor),
             leftPaddingView.bottomAnchor.constraint(equalTo: bottomPaddingView.topAnchor),
-            leftPaddingView.widthAnchor.constraint(equalToConstant: Self.padding),
+            leadingPaddingConstraint,
 
             rightPaddingView.topAnchor.constraint(equalTo: topPaddingView.bottomAnchor),
             rightPaddingView.trailingAnchor.constraint(equalTo: trailingAnchor),
             rightPaddingView.bottomAnchor.constraint(equalTo: bottomPaddingView.topAnchor),
-            rightPaddingView.widthAnchor.constraint(equalToConstant: Self.padding),
+            trailingPaddingConstraint,
 
             bottomPaddingView.leadingAnchor.constraint(equalTo: leadingAnchor),
             bottomPaddingView.trailingAnchor.constraint(equalTo: trailingAnchor),
             bottomPaddingView.bottomAnchor.constraint(equalTo: bottomAnchor),
-            bottomPaddingView.heightAnchor.constraint(equalToConstant: Self.padding),
+            bottomPaddingConstraint,
 
             resizeFeedbackView.centerXAnchor.constraint(equalTo: centerXAnchor),
             resizeFeedbackView.centerYAnchor.constraint(equalTo: centerYAnchor),
@@ -979,10 +999,10 @@ final class TerminalSessionContainerView: NSView {
     override var intrinsicContentSize: NSSize {
         var size = terminal.intrinsicContentSize
         if size.width >= 0 {
-            size.width += Self.padding * 2
+            size.width += CGFloat(terminalPadding.left + terminalPadding.right)
         }
         if size.height >= 0 {
-            size.height += Self.padding * 2
+            size.height += CGFloat(terminalPadding.top + terminalPadding.bottom)
         }
         return size
     }
@@ -1008,6 +1028,17 @@ final class TerminalSessionContainerView: NSView {
         leftPaddingView.layer?.backgroundColor = color
         rightPaddingView.layer?.backgroundColor = color
         bottomPaddingView.layer?.backgroundColor = color
+    }
+
+    func updatePadding(_ padding: TerminalViewPadding) {
+        guard terminalPadding != padding else { return }
+        terminalPadding = padding
+        topPaddingConstraint.constant = CGFloat(padding.top)
+        leadingPaddingConstraint.constant = CGFloat(padding.left)
+        bottomPaddingConstraint.constant = CGFloat(padding.bottom)
+        trailingPaddingConstraint.constant = CGFloat(padding.right)
+        invalidateIntrinsicContentSize()
+        needsLayout = true
     }
 
     private func observeLiveResize(of window: NSWindow) {
@@ -1100,12 +1131,14 @@ struct TerminalSessionView: NSViewRepresentable {
 
     func makeNSView(context: Context) -> TerminalSessionContainerView {
         TerminalSessionContainerView(
-            terminal: controller.makeTerminalView(document: document)
+            terminal: controller.makeTerminalView(document: document),
+            padding: controller.profile.terminalPadding
         )
     }
 
     func updateNSView(_ nsView: TerminalSessionContainerView, context: Context) {
         controller.attach(to: nsView.terminal)
+        nsView.updatePadding(controller.profile.terminalPadding)
         nsView.updatePaddingColor()
     }
 

--- a/TecolotTests/TerminalProfilesTests.swift
+++ b/TecolotTests/TerminalProfilesTests.swift
@@ -513,6 +513,22 @@ final class ProfileStoreTests {
         #expect(profile.termVersion == "1.3.1")
         #expect(profile.useThemeColorsForWindowChrome)
         #expect(profile.hidePointerWhileTyping)
+        #expect(profile.terminalPadding == .standard)
+    }
+
+    @Test func profileRoundTripPreservesPerEdgeTerminalPadding() throws {
+        var profile = TerminalProfile(name: "Padded")
+        profile.terminalPadding = TerminalViewPadding(
+            top: 3,
+            left: 5,
+            bottom: 7,
+            right: 11
+        )
+
+        let data = try ProfileStore.encodedProfile(profile)
+        let decoded = try JSONDecoder().decode(ProfileDocument.self, from: data).profile
+
+        #expect(decoded.terminalPadding == profile.terminalPadding)
     }
 
     @Test func futureProfileRemainsUntouchedAndIsReported() throws {

--- a/TecolotTests/WindowSizingTests.swift
+++ b/TecolotTests/WindowSizingTests.swift
@@ -39,4 +39,17 @@ struct WindowSizingTests {
         #expect(abs(window.contentLayoutRect.width - requestedSize.width) < 0.5)
         #expect(abs(window.contentLayoutRect.height - requestedSize.height) < 0.5)
     }
+
+    @Test func terminalContentSizeIncludesEachPaddingEdge() {
+        let terminalSize = NSSize(width: 640, height: 400)
+        let padding = TerminalViewPadding(top: 3, left: 5, bottom: 7, right: 11)
+
+        let contentSize = TerminalSessionContainerView.contentSize(
+            forTerminalSize: terminalSize,
+            padding: padding
+        )
+
+        #expect(contentSize.width == 656)
+        #expect(contentSize.height == 410)
+    }
 }


### PR DESCRIPTION
A new profile specific setting to adjust the terminal view padding for each edge. 

<img width="800" height="607" alt="CleanShot 2026-09-04 at 09 49 29" src="https://github.com/user-attachments/assets/c806bfcc-a651-4fd3-85af-e42d7c3be263" />

LLM Usage: I used Codex with Sol 4.6 medium to write the code and reviewed with zero issues using Sol 4.6 xhigh. I also reviewed all the code myself.