### PR TITLE
Fix split pane horizontally shortcut

### DIFF
--- a/Tecolot/TecolotApp.swift
+++ b/Tecolot/TecolotApp.swift
@@ -306,7 +306,7 @@ struct TerminalCommands: Commands {
                     controller.workspace?.split(controller, orientation: .horizontal)
                 }
             }
-            .keyboardShortcut("d", modifiers: [.command, .option])
+            .keyboardShortcut("d", modifiers: [.command, .shift])
             .disabled(!isEnabled)
 
             Button("Close Pane") {


### PR DESCRIPTION
`Cmd + shift + d` is a default shortcut on macOS to hide/show the dock so it doesn't work in Tecolot. Also, `Cmd + shift + d` is the default horizontal split shortcut in Ghostty.