### PR TITLE
Fix Swift 6 isolation warnings in ProfileStore

### DIFF
--- a/Tecolot/Profiles/ProfileStore.swift
+++ b/Tecolot/Profiles/ProfileStore.swift
@@ -70,7 +70,7 @@ public final class ProfileStore: ObservableObject {
     private var storeStateIsReadOnly = false
 
     nonisolated static let documentVersion = 1
-    private nonisolated static let builtInDefaultProfile = TerminalProfile(
+    private static let builtInDefaultProfile = TerminalProfile(
         id: UUID(uuidString: "00000000-0000-0000-0000-000000000001")!,
         name: "Default"
     )

--- a/Tecolot/Profiles/ProfileStore.swift
+++ b/Tecolot/Profiles/ProfileStore.swift
@@ -321,13 +321,13 @@ public final class ProfileStore: ObservableObject {
         directory.appendingPathComponent("\(profile.id.uuidString).json")
     }
 
-    nonisolated static func encodedProfile(_ profile: TerminalProfile) throws -> Data {
+    static func encodedProfile(_ profile: TerminalProfile) throws -> Data {
         let encoder = JSONEncoder()
         encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
         return try encoder.encode(ProfileDocument(version: documentVersion, profile: profile))
     }
 
-    nonisolated static func write(profile: TerminalProfile, in directory: URL) throws {
+    static func write(profile: TerminalProfile, in directory: URL) throws {
         try encodedProfile(profile).write(to: url(for: profile, in: directory), options: .atomic)
     }
 


### PR DESCRIPTION
Two small fixes for Swift 6 isolation warnings in `Tecolot/Profiles/ProfileStore.swift`. Both remove a leftover `nonisolated` that dates from when the profile code lived in the separate `TerminalProfileKit` package (moved into the app in 1d20482), where main-actor default isolation did not apply. The app target builds with `SWIFT_DEFAULT_ACTOR_ISOLATION = MainActor`, so these markers now conflict with the types they touch.

**1. `builtInDefaultProfile`**

`TerminalProfile.init(id:name:)` is main actor-isolated, so initializing a `nonisolated` static from it produces:

```
ProfileStore.swift:73:60: warning: call to main actor-isolated initializer 'init(id:name:)' in a synchronous nonisolated context
```

Every use is inside the `@MainActor` `ProfileStore` (`init`, `defaultProfile`, `loadAndCreateDefaultProfileIfNeeded`).

**2. `encodedProfile` and `write(profile:in:)`**

`ProfileDocument`'s synthesized `Codable` conformance is main actor-isolated, so encoding it in the `nonisolated` `encodedProfile` produces:

```
ProfileStore.swift:327:28: warning: main actor-isolated conformance of 'ProfileDocument' to 'Encodable' cannot be used in nonisolated context; this is an error in the Swift 6 language mode
```

Every caller is already main actor-isolated: `ProfileStore`'s own methods, `ProfileDocumentMigrator.encodeCurrent`, and the `@MainActor` `ProfileStoreTests` that call `ProfileStore.write`. `write(profile:in:)` calls `encodedProfile`, so it drops `nonisolated` too. `documentVersion` keeps its `nonisolated`.

**Verification**

Clean Debug builds of `main` (4ceea0b) before and after: the only warning difference is that these two are gone, no new warnings appear, and all 129 `TecolotTests` pass. No behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
